### PR TITLE
Added tests that fail for WindowsProcessesService

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![](https://img.shields.io/maven-central/v/org.jprocesses/jProcesses.svg)
 ![](https://img.shields.io/github/license/profesorfalken/jProcesses.svg)
+![](https://travis-ci.org/profesorfalken/jProcesses.svg)
 
 # jProcesses
 Get crossplatform processes details with Java

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ Get crossplatform processes details with Java
 
 ## Installation ##
 
-To install jProcesses you can add the dependecy to your software project management tool: http://mvnrepository.com/artifact/org.jprocesses/jProcesses/1.2.1
+To install jProcesses you can add the dependecy to your software project management tool: http://mvnrepository.com/artifact/org.jprocesses/jProcesses/1.3
 
 For example, for Maven you have just to add to your pom.xml: 
 
       <dependency>
 	         <groupId>org.jprocesses</groupId>
 	         <artifactId>jProcesses</artifactId>
-         	<version>1.2.1</version>
+         	<version>1.3</version>
       </dependency>
 
 
 Instead, you can direct download the JAR file and add it to your classpath. 
-http://central.maven.org/maven2/org/jprocesses/jProcesses/1.2.1/jProcesses-1.2.1.jar
+http://central.maven.org/maven2/org/jprocesses/jProcesses/1.3/jProcesses-1.3.jar
 
 ## Basic Usage ##
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,15 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jprocesses</groupId>
     <artifactId>jProcesses</artifactId>
-    <version>1.4</version>
+    <version>1.4-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jprocesses</groupId>
     <artifactId>jProcesses</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.3</version>
     <packaging>jar</packaging>
     
     <name>jProcesses</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,18 @@
     <groupId>org.jprocesses</groupId>
     <artifactId>jProcesses</artifactId>
     <version>1.4</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <packaging>jar</packaging>
     
     <name>jProcesses</name>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
             <artifactId>WMI4Java</artifactId>
             <version>1.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.8.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/jutils/jprocesses/info/WindowsProcessesService.java
+++ b/src/main/java/org/jutils/jprocesses/info/WindowsProcessesService.java
@@ -73,7 +73,7 @@ class WindowsProcessesService extends AbstractProcessesService {
     }
 
     public WMI4Java getWmi4Java() {
-        if(wmi4Java == null){
+        if (wmi4Java == null) {
             return WMI4Java.get();
         }
         return wmi4Java;
@@ -91,10 +91,6 @@ class WindowsProcessesService extends AbstractProcessesService {
             }
         }
 
-        /*
-         if (nameFilter != null) {
-         filterByName(processesDataList);
-         }*/
         return processesDataList;
     }
 
@@ -109,15 +105,14 @@ class WindowsProcessesService extends AbstractProcessesService {
             processMap.put(normalizeKey(dataStringInfo[0].trim()),
                     normalizeValue(dataStringInfo[0].trim(), dataStringInfo[1].trim()));
 
-                if ("ProcessId".equals(dataStringInfo[0].trim())) {
-                    processMap.put("user", userData.get(dataStringInfo[1].trim()));
-                    processMap.put("cpu_usage", cpuData.get(dataStringInfo[1].trim()));
-                }
+            if ("ProcessId".equals(dataStringInfo[0].trim())) {
+                processMap.put("user", userData.get(dataStringInfo[1].trim()));
+                processMap.put("cpu_usage", cpuData.get(dataStringInfo[1].trim()));
+            }
 
-                if ("CreationDate".equals(dataStringInfo[0].trim())) {
-                    processMap.put("start_datetime",
-                            ProcessesUtils.parseWindowsDateTimeToFullDate(dataStringInfo[1].trim()));
-                }
+            if ("CreationDate".equals(dataStringInfo[0].trim())) {
+                processMap.put("start_datetime",
+                        ProcessesUtils.parseWindowsDateTimeToFullDate(dataStringInfo[1].trim()));
             }
         }
     }
@@ -129,9 +124,8 @@ class WindowsProcessesService extends AbstractProcessesService {
         }
 
         if (name != null) {
-            return WMI4Java.get().VBSEngine()
-                    .properties(Arrays.asList("Caption", "ProcessId", "Name",
-                                    "UserModeTime", "CommandLine", "WorkingSetSize", "CreationDate", "VirtualSize", "Priority"))
+            return getWmi4Java().VBSEngine().properties(Arrays.asList("Caption", "ProcessId", "Name",
+                    "UserModeTime", "CommandLine", "WorkingSetSize", "CreationDate", "VirtualSize", "Priority"))
                     .filters(Collections.singletonList("Name like '%" + name + "%'"))
                     .getRawWMIObjectOutput(WMIClass.WIN32_PROCESS);
         }

--- a/src/main/java/org/jutils/jprocesses/info/WindowsProcessesService.java
+++ b/src/main/java/org/jutils/jprocesses/info/WindowsProcessesService.java
@@ -47,6 +47,8 @@ class WindowsProcessesService extends AbstractProcessesService {
     
     private static Map<String, String> processMap;
 
+    private final WMI4Java wmi4Java;
+
     static {
         Map<String, String> tmpMap = new HashMap<String, String>();
         tmpMap.put("Name", "proc_name");
@@ -59,6 +61,21 @@ class WindowsProcessesService extends AbstractProcessesService {
         tmpMap.put("CreationDate", "start_time");
 
         keyMap = Collections.unmodifiableMap(tmpMap);
+    }
+
+    public WindowsProcessesService() {
+        this(null);
+    }
+
+    WindowsProcessesService(WMI4Java wmi4Java) {
+        this.wmi4Java = wmi4Java;
+    }
+
+    public WMI4Java getWmi4Java() {
+        if(wmi4Java == null){
+            return WMI4Java.get();
+        }
+        return wmi4Java;
     }
 
     @Override
@@ -90,14 +107,12 @@ class WindowsProcessesService extends AbstractProcessesService {
 
         if (processMap != null) {
             String[] dataStringInfo = dataLine.split(":", 2);
-            if (dataStringInfo.length == 2) {
-                processMap.put(normalizeKey(dataStringInfo[0].trim()),
-                        normalizeValue(dataStringInfo[0].trim(), dataStringInfo[1].trim()));
+            processMap.put(normalizeKey(dataStringInfo[0].trim()),
+                    normalizeValue(dataStringInfo[0].trim(), dataStringInfo[1].trim()));
 
-                if ("ProcessId".equals(dataStringInfo[0].trim())) {
-                    processMap.put("user", userData.get(dataStringInfo[1].trim()));
-                    processMap.put("cpu_usage", cpuData.get(dataStringInfo[1].trim()));
-                }
+            if ("ProcessId".equals(dataStringInfo[0].trim())) {
+                processMap.put("user", userData.get(dataStringInfo[1].trim()));
+                processMap.put("cpu_usage", cpuData.get(dataStringInfo[1].trim()));
             }
         }
     }
@@ -110,7 +125,7 @@ class WindowsProcessesService extends AbstractProcessesService {
             this.nameFilter = name;
         }
 
-        return WMI4Java.get().VBSEngine().getRawWMIObjectOutput(WMIClass.WIN32_PROCESS);
+        return getWmi4Java().VBSEngine().getRawWMIObjectOutput(WMIClass.WIN32_PROCESS);
     }
 
     @Override
@@ -169,7 +184,7 @@ class WindowsProcessesService extends AbstractProcessesService {
     }
 
     private void fillExtraProcessData() {
-        String perfData = WMI4Java.get().VBSEngine().getRawWMIObjectOutput(WMIClass.WIN32_PERFFORMATTEDDATA_PERFPROC_PROCESS);
+        String perfData = getWmi4Java().VBSEngine().getRawWMIObjectOutput(WMIClass.WIN32_PERFFORMATTEDDATA_PERFPROC_PROCESS);
 
         String[] dataStringLines = perfData.split(LINE_BREAK_REGEX);
         String pid = null;

--- a/src/main/java/org/jutils/jprocesses/info/WindowsProcessesService.java
+++ b/src/main/java/org/jutils/jprocesses/info/WindowsProcessesService.java
@@ -164,7 +164,7 @@ class WindowsProcessesService extends AbstractProcessesService {
             return nomalizeTime(seconds);
         }
         if ("VirtualSize".equals(origKey) || "WorkingSetSize".equals(origKey)) {
-            if (!(origValue.isEmpty())) {
+            if (origValue != null && origValue.length() > 0) {
                 return String.valueOf(Long.parseLong(origValue) / 1024);
             }
         }
@@ -232,11 +232,10 @@ class WindowsProcessesService extends AbstractProcessesService {
         return null;
     }
 
-    @Override
     public JProcessesResponse changePriority(int pid, int priority) {
         JProcessesResponse response = new JProcessesResponse();
         String message = VBScriptHelper.changePriority(pid, priority);
-        if (message.isEmpty()) {
+        if (message == null || message.length() == 0) {
             response.setSuccess(true);
         } else {
             response.setMessage(message);
@@ -244,12 +243,10 @@ class WindowsProcessesService extends AbstractProcessesService {
         return response;
     }
 
-    @Override
     public ProcessInfo getProcess(int pid) {
         return getProcess(pid, false);
     }
 
-    @Override
     public ProcessInfo getProcess(int pid, boolean fastMode) {
         this.fastMode = fastMode;
         List<Map<String, String>> allProcesses = parseList(getProcessesData(null));

--- a/src/main/java/org/jutils/jprocesses/info/WindowsProcessesService.java
+++ b/src/main/java/org/jutils/jprocesses/info/WindowsProcessesService.java
@@ -44,6 +44,8 @@ class WindowsProcessesService extends AbstractProcessesService {
     private static final String LINE_BREAK_REGEX = "\\r?\\n";
 
     private static final Map<String, String> keyMap;
+    
+    private static Map<String, String> processMap;
 
     static {
         Map<String, String> tmpMap = new HashMap<String, String>();
@@ -79,7 +81,6 @@ class WindowsProcessesService extends AbstractProcessesService {
     }
 
     private void processLine(String dataLine, List<Map<String, String>> processesDataList) {
-        Map<String, String> processMap = null;
         if (dataLine.startsWith("Caption")) {
             if (processMap != null && processMap.size() > 0) {
                 processesDataList.add(processMap);
@@ -179,12 +180,18 @@ class WindowsProcessesService extends AbstractProcessesService {
                 if (dataLine.startsWith("Caption")) {
                     if (pid != null && cpuUsage != null) {
                         cpuData.put(pid, cpuUsage);
+                        pid = null;
+                        cpuUsage = null;
                     }
                     continue;
                 }
                 
-                pid = checkAndGetDataInLine("IDProcess", dataLine);
-                cpuUsage = checkAndGetDataInLine("PercentProcessorTime", dataLine);
+                if (pid == null) {
+                    pid = checkAndGetDataInLine("IDProcess", dataLine);
+                }
+                if (cpuUsage == null) {
+                    cpuUsage = checkAndGetDataInLine("PercentProcessorTime", dataLine);
+                }
             }
         }
 

--- a/src/main/java/org/jutils/jprocesses/model/ProcessInfo.java
+++ b/src/main/java/org/jutils/jprocesses/model/ProcessInfo.java
@@ -33,6 +33,22 @@ public class ProcessInfo {
     private String priority;
     private String command;
 
+    public ProcessInfo() {
+    }
+
+    public ProcessInfo(String pid, String time, String name, String user, String virtualMemory, String physicalMemory, String cpuUsage, String startTime, String priority, String command) {
+        this.pid = pid;
+        this.time = time;
+        this.name = name;
+        this.user = user;
+        this.virtualMemory = virtualMemory;
+        this.physicalMemory = physicalMemory;
+        this.cpuUsage = cpuUsage;
+        this.startTime = startTime;
+        this.priority = priority;
+        this.command = command;
+    }
+
     public String getPid() {
         return pid;
     }
@@ -111,6 +127,43 @@ public class ProcessInfo {
 
     public void setPriority(String priority) {
         this.priority = priority;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ProcessInfo that = (ProcessInfo) o;
+
+        if (pid != null ? !pid.equals(that.pid) : that.pid != null) return false;
+        if (time != null ? !time.equals(that.time) : that.time != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+//        if (user != null ? !user.equals(that.user) : that.user != null) return false;
+//        if (virtualMemory != null ? !virtualMemory.equals(that.virtualMemory) : that.virtualMemory != null)
+//            return false;
+//        if (physicalMemory != null ? !physicalMemory.equals(that.physicalMemory) : that.physicalMemory != null)
+//            return false;
+//        if (cpuUsage != null ? !cpuUsage.equals(that.cpuUsage) : that.cpuUsage != null) return false;
+        if (startTime != null ? !startTime.equals(that.startTime) : that.startTime != null) return false;
+        if (priority != null ? !priority.equals(that.priority) : that.priority != null) return false;
+        return command != null ? command.equals(that.command) : that.command == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pid != null ? pid.hashCode() : 0;
+        result = 31 * result + (time != null ? time.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+//        result = 31 * result + (user != null ? user.hashCode() : 0)   //TODO: return this to equals and hashcode after getProcessesOwner refactoring
+//        result = 31 * result + (virtualMemory != null ? virtualMemory.hashCode() : 0);
+//        result = 31 * result + (physicalMemory != null ? physicalMemory.hashCode() : 0);
+//        result = 31 * result + (cpuUsage != null ? cpuUsage.hashCode() : 0);
+        result = 31 * result + (startTime != null ? startTime.hashCode() : 0);
+        result = 31 * result + (priority != null ? priority.hashCode() : 0);
+        result = 31 * result + (command != null ? command.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/src/test/java/org/jutils/jprocesses/JProcessesTest.java
+++ b/src/test/java/org/jutils/jprocesses/JProcessesTest.java
@@ -1,16 +1,18 @@
 package org.jutils.jprocesses;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.jutils.jprocesses.model.ProcessInfo;
 import org.jutils.jprocesses.model.WindowsPriority;
 import org.jutils.jprocesses.util.OSDetector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  *

--- a/src/test/java/org/jutils/jprocesses/info/WindowsProcessesServiceTest.java
+++ b/src/test/java/org/jutils/jprocesses/info/WindowsProcessesServiceTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -57,7 +58,11 @@ public class WindowsProcessesServiceTest {
 
     @Test
     public void testGetListWithName() {
-
+        when(wmi4Java.properties(anyList())).thenReturn(wmi4Java);
+        when(wmi4Java.filters(anyList())).thenReturn(wmi4Java);
+        when(wmi4Java.filters(anyList())).thenReturn(wmi4Java);
+        when(wmi4Java.getRawWMIObjectOutput(eq(WMIClass.WIN32_PROCESS))).thenReturn(WMI_PROCESS4 + WMI_PROCESS5);
+        when(wmi4Java.getRawWMIObjectOutput(eq(WMIClass.WIN32_PERFFORMATTEDDATA_PERFPROC_PROCESS))).thenReturn(WMI_PROCESS4_PERF + WMI_PROCESS5_PERF);
         List<ProcessInfo> list = srv.getList("java.exe");
         assertEquals(2,list.size());
         assertTrue(list.contains(processInfo4));

--- a/src/test/java/org/jutils/jprocesses/info/WindowsProcessesServiceTest.java
+++ b/src/test/java/org/jutils/jprocesses/info/WindowsProcessesServiceTest.java
@@ -1,0 +1,481 @@
+package org.jutils.jprocesses.info;
+
+import com.profesorfalken.wmi4java.WMI4Java;
+import com.profesorfalken.wmi4java.WMIClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.jutils.jprocesses.model.ProcessInfo;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+public class WindowsProcessesServiceTest {
+
+    @Mock
+    WMI4Java wmi4Java;
+    WindowsProcessesService srv;
+    ProcessInfo processInfo1;
+    ProcessInfo processInfo2;
+    ProcessInfo processInfo3;
+    ProcessInfo processInfo4;
+    ProcessInfo processInfo5;
+
+    @Before
+    public void setUp(){
+        MockitoAnnotations.initMocks(this);
+        srv = new WindowsProcessesService(wmi4Java);
+        processInfo1 = new ProcessInfo("3644","00:09:568","idea64.exe","Denis","4188632","1056660","100","13:58:15","8", "\"C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\bin\\idea64.exe\"");
+        processInfo2 = new ProcessInfo("6936","00:01:85","DOOMx64.exe","Denis","2429212","1023348","6","14:47:12","8", "\"D:\\SteamLibrary\\steamapps\\common\\DOOM\\DOOMx64.exe\"");
+        processInfo3 = new ProcessInfo("2876","00:03:194","chrome.exe","Denis","554672","141348","0","11:54:00","8", "\"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe\" --no-startup-window /prefetch:5");
+        processInfo4 = new ProcessInfo("6700","00:00:01","java.exe","Denis","2006344","83756","2","13:58:45","8", "\"C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\bin\\java\" -Djava.awt.headless=true -Didea.version==2016.1.2 -Xmx512m -Didea.maven.embedder.version=3.0.5 -Dfile.encoding=windows-1251 -classpath \"C:/Program Files (x86)/JetBrains/IntelliJ IDEA Community Edition 2016.1/lib/resources_en.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\log4j.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\slf4j-api-1.7.10.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\slf4j-log4j12-1.7.10.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\jna.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\resources_en.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\util.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\oromatcher.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\annotations.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\snappy-in-java-0.3.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\trove4j.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\jna-platform.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\jdom.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\picocontainer.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\lucene-core-2.4.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven-server-api.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-common.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\archetype-catalog-2.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\archetype-common-2.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\maven-dependency-tree-1.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\nexus-indexer-3.0.4.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\nexus-indexer-artifact-1.0.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven30-server-impl.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-api-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-connector-wagon-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-impl-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-spi-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-util-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\commons-cli-1.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\commons-io-2.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\commons-lang-2.6.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-aether-provider-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-artifact-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-compat-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-core-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-embedder-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-model-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-model-builder-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-plugin-api-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-repository-metadata-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-settings-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-settings-builder-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-cipher-1.7.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-component-annotations-1.5.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-interpolation-1.14.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-sec-dispatcher-1.3.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-utils-2.0.6.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\sisu-guava-0.9.9.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\sisu-guice-3.1.0-no_aop.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\sisu-inject-bean-2.3.0.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\sisu-inject-plexus-2.3.0.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\wagon-file-2.8.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\wagon-http-2.8-shaded.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\wagon-http-shared-2.8.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\wagon-provider-api-2.8.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\boot\\plexus-classworlds-2.4.jar\" org.jetbrains.idea.maven.server.RemoteMavenServer");
+        processInfo5 = new ProcessInfo("8160","00:00:00","java.exe","Denis","3596832","461036","3","15:18:48","8", "\"C:\\Program Files\\Java\\jdk1.8.0_60\\bin\\java\" -agentlib:jdwp=transport=dt_socket,address=127.0.0.1:53995,suspend=y,server=n -ea -Didea.junit.sm_runner -Dfile.encoding=UTF-8 -classpath \"C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\idea_rt.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\junit\\lib\\junit-rt.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\charsets.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\deploy.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\javaws.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\jce.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\jfr.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\jfxswt.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\jsse.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\management-agent.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\plugin.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\resources.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\rt.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\access-bridge-64.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\cldrdata.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\dnsns.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\jaccess.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\jfxrt.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\localedata.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\nashorn.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\sunec.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\sunjce_provider.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\sunmscapi.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\sunpkcs11.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\zipfs.jar;D:\\dev\\jProcesses\\target\\test-classes;D:\\dev\\jProcesses\\target\\classes;C:\\Users\\Denis\\.m2\\repository\\junit\\junit\\4.10\\junit-4.10.jar;C:\\Users\\Denis\\.m2\\repository\\org\\hamcrest\\hamcrest-core\\1.1\\hamcrest-core-1.1.jar;C:\\Users\\Denis\\.m2\\repository\\com\\profesorfalken\\WMI4Java\\1.1\\WMI4Java-1.1.jar;C:\\Users\\Denis\\.m2\\repository\\com\\profesorfalken\\jPowerShell\\1.3\\jPowerShell-1.3.jar;C:\\Users\\Denis\\.m2\\repository\\org\\mockito\\mockito-all\\1.8.4\\mockito-all-1.8.4.jar\" com.intellij.rt.execution.junit.JUnitStarter -ideVersion5 org.jutils.jprocesses.info.WindowsProcessesServiceTest,testGetListWithName");
+        when(wmi4Java.getRawWMIObjectOutput(eq(WMIClass.WIN32_PROCESS))).thenReturn(WMI_PROCESS1 + WMI_PROCESS2 + WMI_PROCESS3 + WMI_PROCESS4 + WMI_PROCESS5);
+        when(wmi4Java.getRawWMIObjectOutput(eq(WMIClass.WIN32_PERFFORMATTEDDATA_PERFPROC_PROCESS))).thenReturn(WMI_PROCESS1_PERF + WMI_PROCESS2_PERF + WMI_PROCESS3_PERF + WMI_PROCESS4_PERF + WMI_PROCESS5_PERF);
+        when(wmi4Java.VBSEngine()).thenReturn(wmi4Java);
+    }
+    /**
+     * Test of getProcessList method, of class JProcesses.
+     */
+    @Test
+    public void testGetList() {
+
+        List<ProcessInfo> list = srv.getList();
+        assertEquals(5,list.size());
+        assertTrue(list.contains(processInfo1));
+        assertTrue(list.contains(processInfo2));
+        assertTrue(list.contains(processInfo3));
+        assertTrue(list.contains(processInfo4));
+        assertTrue(list.contains(processInfo5));
+
+    }
+
+    @Test
+    public void testGetListWithName() {
+
+        List<ProcessInfo> list = srv.getList("java.exe");
+        assertEquals(2,list.size());
+        assertTrue(list.contains(processInfo4));
+        assertTrue(list.contains(processInfo5));
+    }
+
+    private static final String WMI_PROCESS1 = "Caption: idea64.exe\n" +
+            "CommandLine: \"C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\bin\\idea64.exe\" \n" +
+            "CreationClassName: Win32_Process\n" +
+            "CreationDate: 20160514135815.444566+180\n" +
+            "CSCreationClassName: Win32_ComputerSystem\n" +
+            "CSName: DENIS-PC\n" +
+            "Description: idea64.exe\n" +
+            "ExecutablePath: C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\bin\\idea64.exe\n" +
+            "ExecutionState: \n" +
+            "Handle: 3644\n" +
+            "HandleCount: 910\n" +
+            "InstallDate: \n" +
+            "KernelModeTime: 524007359\n" +
+            "MaximumWorkingSetSize: 1380\n" +
+            "MinimumWorkingSetSize: 200\n" +
+            "Name: idea64.exe\n" +
+            "OSCreationClassName: Win32_OperatingSystem\n" +
+            "OSName: Microsoft Windows 7 Ultimate |C:\\Windows|\\Device\\Harddisk0\\Partition2\n" +
+            "OtherOperationCount: 1934035\n" +
+            "OtherTransferCount: 35525870\n" +
+            "PageFaults: 2541972\n" +
+            "PageFileUsage: 1117360\n" +
+            "ParentProcessId: 500\n" +
+            "PeakPageFileUsage: 1133232\n" +
+            "PeakVirtualSize: 4297838592\n" +
+            "PeakWorkingSetSize: 1071420\n" +
+            "Priority: 8\n" +
+            "PrivatePageCount: 1144176640\n" +
+            "ProcessId: 3644\n" +
+            "QuotaNonPagedPoolUsage: 75\n" +
+            "QuotaPagedPoolUsage: 304\n" +
+            "QuotaPeakNonPagedPoolUsage: 81\n" +
+            "QuotaPeakPagedPoolUsage: 326\n" +
+            "ReadOperationCount: 178223\n" +
+            "ReadTransferCount: 661366634\n" +
+            "SessionId: 1\n" +
+            "Status: \n" +
+            "TerminationDate: \n" +
+            "ThreadCount: 64\n" +
+            "UserModeTime: 5684832441\n" +
+            "VirtualSize: 4289159168\n" +
+            "WindowsVersion: 6.1.7601\n" +
+            "WorkingSetSize: 1082019840\n" +
+            "WriteOperationCount: 4141\n" +
+            "WriteTransferCount: 1499671310\n";
+
+    private static final String WMI_PROCESS2 = "Caption: DOOMx64.exe\n" +
+            "CommandLine: \"D:\\SteamLibrary\\steamapps\\common\\DOOM\\DOOMx64.exe\"\n" +
+            "CreationClassName: Win32_Process\n" +
+            "CreationDate: 20160514144712.680566+180\n" +
+            "CSCreationClassName: Win32_ComputerSystem\n" +
+            "CSName: DENIS-PC\n" +
+            "Description: DOOMx64.exe\n" +
+            "ExecutablePath: D:\\SteamLibrary\\steamapps\\common\\DOOM\\DOOMx64.exe\n" +
+            "ExecutionState:\n" +
+            "Handle: 6936\n" +
+            "HandleCount: 1110\n" +
+            "InstallDate:\n" +
+            "KernelModeTime: 709960551\n" +
+            "MaximumWorkingSetSize: 628680\n" +
+            "MinimumWorkingSetSize: 628568\n" +
+            "Name: DOOMx64.exe\n" +
+            "OSCreationClassName: Win32_OperatingSystem\n" +
+            "OSName: Microsoft Windows 7 Ultimate |C:\\Windows|\\Device\\Harddisk0\\Partition2\n" +
+            "OtherOperationCount: 10494\n" +
+            "OtherTransferCount: 109196\n" +
+            "PageFaults: 386552\n" +
+            "PageFileUsage: 1585468\n" +
+            "ParentProcessId: 2548\n" +
+            "PeakPageFileUsage: 1585476\n" +
+            "PeakVirtualSize: 2490068992\n" +
+            "PeakWorkingSetSize: 1023348\n" +
+            "Priority: 8\n" +
+            "PrivatePageCount: 1623519232\n" +
+            "ProcessId: 6936\n" +
+            "QuotaNonPagedPoolUsage: 128\n" +
+            "QuotaPagedPoolUsage: 3330\n" +
+            "QuotaPeakNonPagedPoolUsage: 128\n" +
+            "QuotaPeakPagedPoolUsage: 3340\n" +
+            "ReadOperationCount: 2376\n" +
+            "ReadTransferCount: 2433886942\n" +
+            "SessionId: 1\n" +
+            "Status:\n" +
+            "TerminationDate:\n" +
+            "ThreadCount: 33\n" +
+            "UserModeTime: 857069494\n" +
+            "VirtualSize: 2487513088\n" +
+            "WindowsVersion: 6.1.7601\n" +
+            "WorkingSetSize: 1047908352\n" +
+            "WriteOperationCount: 210\n" +
+            "WriteTransferCount: 11894\n";
+    private static final String WMI_PROCESS3 = "Caption: chrome.exe\n" +
+            "CommandLine: \"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe\" --no-startup-window /prefetch:5\n" +
+            "CreationClassName: Win32_Process\n" +
+            "CreationDate: 20160514115400.098497+180\n" +
+            "CSCreationClassName: Win32_ComputerSystem\n" +
+            "CSName: DENIS-PC\n" +
+            "Description: chrome.exe\n" +
+            "ExecutablePath: C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe\n" +
+            "ExecutionState:\n" +
+            "Handle: 2876\n" +
+            "HandleCount: 1265\n" +
+            "InstallDate:\n" +
+            "KernelModeTime: 661912243\n" +
+            "MaximumWorkingSetSize: 1380\n" +
+            "MinimumWorkingSetSize: 200\n" +
+            "Name: chrome.exe\n" +
+            "OSCreationClassName: Win32_OperatingSystem\n" +
+            "OSName: Microsoft Windows 7 Ultimate |C:\\Windows|\\Device\\Harddisk0\\Partition2\n" +
+            "OtherOperationCount: 493715\n" +
+            "OtherTransferCount: 18990227\n" +
+            "PageFaults: 1548415\n" +
+            "PageFileUsage: 104732\n" +
+            "ParentProcessId: 500\n" +
+            "PeakPageFileUsage: 138056\n" +
+            "PeakVirtualSize: 764755968\n" +
+            "PeakWorkingSetSize: 171256\n" +
+            "Priority: 8\n" +
+            "PrivatePageCount: 107245568\n" +
+            "ProcessId: 2876\n" +
+            "QuotaNonPagedPoolUsage: 65\n" +
+            "QuotaPagedPoolUsage: 852\n" +
+            "QuotaPeakNonPagedPoolUsage: 232\n" +
+            "QuotaPeakPagedPoolUsage: 1247\n" +
+            "ReadOperationCount: 1549009\n" +
+            "ReadTransferCount: 1148378511\n" +
+            "SessionId: 1\n" +
+            "Status:\n" +
+            "TerminationDate:\n" +
+            "ThreadCount: 39\n" +
+            "UserModeTime: 1948764492\n" +
+            "VirtualSize: 567984128\n" +
+            "WindowsVersion: 6.1.7601\n" +
+            "WorkingSetSize: 144740352\n" +
+            "WriteOperationCount: 1793811\n" +
+            "WriteTransferCount: 1503510606\n";
+    private static final String WMI_PROCESS4 = "Caption: java.exe\n" +
+            "CommandLine: \"C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\bin\\java\" -Djava.awt.headless=true -Didea.version==2016.1.2 -Xmx512m -Didea.maven.embedder.version=3.0.5 -Dfile.encoding=windows-1251 -classpath \"C:/Program Files (x86)/JetBrains/IntelliJ IDEA Community Edition 2016.1/lib/resources_en.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\log4j.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\slf4j-api-1.7.10.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\slf4j-log4j12-1.7.10.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\jna.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\resources_en.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\util.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\oromatcher.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\annotations.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\snappy-in-java-0.3.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\trove4j.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\jna-platform.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\jdom.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\picocontainer.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\lucene-core-2.4.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven-server-api.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-common.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\archetype-catalog-2.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\archetype-common-2.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\maven-dependency-tree-1.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\nexus-indexer-3.0.4.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3-server-lib\\nexus-indexer-artifact-1.0.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven30-server-impl.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-api-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-connector-wagon-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-impl-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-spi-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\aether-util-1.13.1.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\commons-cli-1.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\commons-io-2.2.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\commons-lang-2.6.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-aether-provider-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-artifact-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-compat-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-core-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-embedder-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-model-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-model-builder-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-plugin-api-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-repository-metadata-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-settings-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\maven-settings-builder-3.0.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-cipher-1.7.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-component-annotations-1.5.5.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-interpolation-1.14.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-sec-dispatcher-1.3.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\plexus-utils-2.0.6.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\sisu-guava-0.9.9.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\sisu-guice-3.1.0-no_aop.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\sisu-inject-bean-2.3.0.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\sisu-inject-plexus-2.3.0.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\wagon-file-2.8.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\wagon-http-2.8-shaded.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\wagon-http-shared-2.8.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\lib\\wagon-provider-api-2.8.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\maven\\lib\\maven3\\boot\\plexus-classworlds-2.4.jar\" org.jetbrains.idea.maven.server.RemoteMavenServer\n" +
+            "CreationClassName: Win32_Process\n" +
+            "CreationDate: 20160514135845.836304+180\n" +
+            "CSCreationClassName: Win32_ComputerSystem\n" +
+            "CSName: DENIS-PC\n" +
+            "Description: java.exe\n" +
+            "ExecutablePath: C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\bin\\java.exe\n" +
+            "ExecutionState: \n" +
+            "Handle: 6700\n" +
+            "HandleCount: 324\n" +
+            "InstallDate: \n" +
+            "KernelModeTime: 1716011\n" +
+            "MaximumWorkingSetSize: 1380\n" +
+            "MinimumWorkingSetSize: 200\n" +
+            "Name: java.exe\n" +
+            "OSCreationClassName: Win32_OperatingSystem\n" +
+            "OSName: Microsoft Windows 7 Ultimate |C:\\Windows|\\Device\\Harddisk0\\Partition2\n" +
+            "OtherOperationCount: 12619\n" +
+            "OtherTransferCount: 274107\n" +
+            "PageFaults: 34915\n" +
+            "PageFileUsage: 240784\n" +
+            "ParentProcessId: 3644\n" +
+            "PeakPageFileUsage: 245768\n" +
+            "PeakVirtualSize: 2058690560\n" +
+            "PeakWorkingSetSize: 94992\n" +
+            "Priority: 8\n" +
+            "PrivatePageCount: 246562816\n" +
+            "ProcessId: 6700\n" +
+            "QuotaNonPagedPoolUsage: 22\n" +
+            "QuotaPagedPoolUsage: 169\n" +
+            "QuotaPeakNonPagedPoolUsage: 26\n" +
+            "QuotaPeakPagedPoolUsage: 171\n" +
+            "ReadOperationCount: 9873\n" +
+            "ReadTransferCount: 11487969\n" +
+            "SessionId: 1\n" +
+            "Status: \n" +
+            "TerminationDate: \n" +
+            "ThreadCount: 24\n" +
+            "UserModeTime: 18252117\n" +
+            "VirtualSize: 2054496256\n" +
+            "WindowsVersion: 6.1.7601\n" +
+            "WorkingSetSize: 85766144\n" +
+            "WriteOperationCount: 118\n" +
+            "WriteTransferCount: 3848\n";
+
+    private static final String WMI_PROCESS5 = "Caption: java.exe\n" +
+            "CommandLine: \"C:\\Program Files\\Java\\jdk1.8.0_60\\bin\\java\" -agentlib:jdwp=transport=dt_socket,address=127.0.0.1:53995,suspend=y,server=n -ea -Didea.junit.sm_runner -Dfile.encoding=UTF-8 -classpath \"C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\lib\\idea_rt.jar;C:\\Program Files (x86)\\JetBrains\\IntelliJ IDEA Community Edition 2016.1\\plugins\\junit\\lib\\junit-rt.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\charsets.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\deploy.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\javaws.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\jce.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\jfr.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\jfxswt.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\jsse.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\management-agent.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\plugin.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\resources.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\rt.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\access-bridge-64.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\cldrdata.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\dnsns.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\jaccess.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\jfxrt.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\localedata.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\nashorn.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\sunec.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\sunjce_provider.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\sunmscapi.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\sunpkcs11.jar;C:\\Program Files\\Java\\jdk1.8.0_60\\jre\\lib\\ext\\zipfs.jar;D:\\dev\\jProcesses\\target\\test-classes;D:\\dev\\jProcesses\\target\\classes;C:\\Users\\Denis\\.m2\\repository\\junit\\junit\\4.10\\junit-4.10.jar;C:\\Users\\Denis\\.m2\\repository\\org\\hamcrest\\hamcrest-core\\1.1\\hamcrest-core-1.1.jar;C:\\Users\\Denis\\.m2\\repository\\com\\profesorfalken\\WMI4Java\\1.1\\WMI4Java-1.1.jar;C:\\Users\\Denis\\.m2\\repository\\com\\profesorfalken\\jPowerShell\\1.3\\jPowerShell-1.3.jar;C:\\Users\\Denis\\.m2\\repository\\org\\mockito\\mockito-all\\1.8.4\\mockito-all-1.8.4.jar\" com.intellij.rt.execution.junit.JUnitStarter -ideVersion5 org.jutils.jprocesses.info.WindowsProcessesServiceTest,testGetListWithName\n" +
+            "CreationClassName: Win32_Process\n" +
+            "CreationDate: 20160514151848.264987+180\n" +
+            "CSCreationClassName: Win32_ComputerSystem\n" +
+            "CSName: DENIS-PC\n" +
+            "Description: java.exe\n" +
+            "ExecutablePath: C:\\Program Files\\Java\\jdk1.8.0_60\\bin\\java.exe\n" +
+            "ExecutionState: \n" +
+            "Handle: 8160\n" +
+            "HandleCount: 252\n" +
+            "InstallDate: \n" +
+            "KernelModeTime: 2808018\n" +
+            "MaximumWorkingSetSize: 1380\n" +
+            "MinimumWorkingSetSize: 200\n" +
+            "Name: java.exe\n" +
+            "OSCreationClassName: Win32_OperatingSystem\n" +
+            "OSName: Microsoft Windows 7 Ultimate |C:\\Windows|\\Device\\Harddisk0\\Partition2\n" +
+            "OtherOperationCount: 7038\n" +
+            "OtherTransferCount: 163028\n" +
+            "PageFaults: 118732\n" +
+            "PageFileUsage: 892380\n" +
+            "ParentProcessId: 3644\n" +
+            "PeakPageFileUsage: 894172\n" +
+            "PeakVirtualSize: 3683155968\n" +
+            "PeakWorkingSetSize: 462196\n" +
+            "Priority: 8\n" +
+            "PrivatePageCount: 913797120\n" +
+            "ProcessId: 8160\n" +
+            "QuotaNonPagedPoolUsage: 20\n" +
+            "QuotaPagedPoolUsage: 178\n" +
+            "QuotaPeakNonPagedPoolUsage: 119\n" +
+            "QuotaPeakPagedPoolUsage: 178\n" +
+            "ReadOperationCount: 4176\n" +
+            "ReadTransferCount: 6494968\n" +
+            "SessionId: 1\n" +
+            "Status: \n" +
+            "TerminationDate: \n" +
+            "ThreadCount: 20\n" +
+            "UserModeTime: 8268053\n" +
+            "VirtualSize: 3683155968\n" +
+            "WindowsVersion: 6.1.7601\n" +
+            "WorkingSetSize: 472100864\n" +
+            "WriteOperationCount: 14\n" +
+            "WriteTransferCount: 6635\n";
+
+    private static final String WMI_PROCESS1_PERF ="Caption: \n" +
+            "CreatingProcessID: 2548\n" +
+            "Description: \n" +
+            "ElapsedTime: 361\n" +
+            "Frequency_Object: \n" +
+            "Frequency_PerfTime: \n" +
+            "Frequency_Sys100NS: \n" +
+            "HandleCount: 1739\n" +
+            "IDProcess: 6936\n" +
+            "IODataBytesPersec: 3631675\n" +
+            "IODataOperationsPersec: 265\n" +
+            "IOOtherBytesPersec: 949\n" +
+            "IOOtherOperationsPersec: 296\n" +
+            "IOReadBytesPersec: 3630607\n" +
+            "IOReadOperationsPersec: 146\n" +
+            "IOWriteBytesPersec: 1068\n" +
+            "IOWriteOperationsPersec: 118\n" +
+            "Name: DOOMx64\n" +
+            "PageFaultsPersec: 0\n" +
+            "PageFileBytes: 2646224896\n" +
+            "PageFileBytesPeak: 2648330240\n" +
+            "PercentPrivilegedTime: 67\n" +
+            "PercentProcessorTime: 100\n" +
+            "PercentUserTime: 80\n" +
+            "PoolNonpagedBytes: 301176\n" +
+            "PoolPagedBytes: 2782520\n" +
+            "PriorityBase: 8\n" +
+            "PrivateBytes: 2646224896\n" +
+            "ThreadCount: 36\n" +
+            "Timestamp_Object: \n" +
+            "Timestamp_PerfTime: \n" +
+            "Timestamp_Sys100NS: \n" +
+            "VirtualBytes: 3179716608\n" +
+            "VirtualBytesPeak: 3231305728\n" +
+            "WorkingSet: 2166816768\n" +
+            "WorkingSetPeak: 2166833152\n" +
+            "WorkingSetPrivate: 1682055168\n";
+    private static final String WMI_PROCESS2_PERF = "Caption: \n" +
+            "CreatingProcessID: 500\n" +
+            "Description: \n" +
+            "ElapsedTime: 3298\n" +
+            "Frequency_Object: \n" +
+            "Frequency_PerfTime: \n" +
+            "Frequency_Sys100NS: \n" +
+            "HandleCount: 917\n" +
+            "IDProcess: 3644\n" +
+            "IODataBytesPersec: 1867\n" +
+            "IODataOperationsPersec: 11\n" +
+            "IOOtherBytesPersec: 13672\n" +
+            "IOOtherOperationsPersec: 854\n" +
+            "IOReadBytesPersec: 1867\n" +
+            "IOReadOperationsPersec: 11\n" +
+            "IOWriteBytesPersec: 0\n" +
+            "IOWriteOperationsPersec: 0\n" +
+            "Name: idea64\n" +
+            "PageFaultsPersec: 3\n" +
+            "PageFileBytes: 1155874816\n" +
+            "PageFileBytesPeak: 1166286848\n" +
+            "PercentPrivilegedTime: 0\n" +
+            "PercentProcessorTime: 6\n" +
+            "PercentUserTime: 6\n" +
+            "PoolNonpagedBytes: 74096\n" +
+            "PoolPagedBytes: 310792\n" +
+            "PriorityBase: 8\n" +
+            "PrivateBytes: 1155874816\n" +
+            "ThreadCount: 65\n" +
+            "Timestamp_Object: \n" +
+            "Timestamp_PerfTime: \n" +
+            "Timestamp_Sys100NS: \n" +
+            "VirtualBytes: 4290207744\n" +
+            "VirtualBytesPeak: 4300398592\n" +
+            "WorkingSet: 1061761024\n" +
+            "WorkingSetPeak: 1097666560\n" +
+            "WorkingSetPrivate: 1050238976\n";
+    private static final String WMI_PROCESS3_PERF = "Caption: \n" +
+            "CreatingProcessID: 500\n" +
+            "Description: \n" +
+            "ElapsedTime: 10753\n" +
+            "Frequency_Object: \n" +
+            "Frequency_PerfTime: \n" +
+            "Frequency_Sys100NS: \n" +
+            "HandleCount: 1259\n" +
+            "IDProcess: 2876\n" +
+            "IODataBytesPersec: 236304\n" +
+            "IODataOperationsPersec: 522\n" +
+            "IOOtherBytesPersec: 443\n" +
+            "IOOtherOperationsPersec: 106\n" +
+            "IOReadBytesPersec: 107811\n" +
+            "IOReadOperationsPersec: 174\n" +
+            "IOWriteBytesPersec: 128493\n" +
+            "IOWriteOperationsPersec: 348\n" +
+            "Name: chrome\n" +
+            "PageFaultsPersec: 0\n" +
+            "PageFileBytes: 107134976\n" +
+            "PageFileBytesPeak: 141369344\n" +
+            "PercentPrivilegedTime: 0\n" +
+            "PercentProcessorTime: 0\n" +
+            "PercentUserTime: 0\n" +
+            "PoolNonpagedBytes: 63448\n" +
+            "PoolPagedBytes: 870848\n" +
+            "PriorityBase: 8\n" +
+            "PrivateBytes: 107134976\n" +
+            "ThreadCount: 37\n" +
+            "Timestamp_Object: \n" +
+            "Timestamp_PerfTime: \n" +
+            "Timestamp_Sys100NS: \n" +
+            "VirtualBytes: 565362688\n" +
+            "VirtualBytesPeak: 764755968\n" +
+            "WorkingSet: 132898816\n" +
+            "WorkingSetPeak: 175366144\n" +
+            "WorkingSetPrivate: 86532096\n";
+    private static final String WMI_PROCESS4_PERF = "Caption: \n" +
+            "CreatingProcessID: 3644\n" +
+            "Description: \n" +
+            "ElapsedTime: 4808\n" +
+            "Frequency_Object: \n" +
+            "Frequency_PerfTime: \n" +
+            "Frequency_Sys100NS: \n" +
+            "HandleCount: 325\n" +
+            "IDProcess: 6700\n" +
+            "IODataBytesPersec: 0\n" +
+            "IODataOperationsPersec: 0\n" +
+            "IOOtherBytesPersec: 0\n" +
+            "IOOtherOperationsPersec: 0\n" +
+            "IOReadBytesPersec: 0\n" +
+            "IOReadOperationsPersec: 0\n" +
+            "IOWriteBytesPersec: 0\n" +
+            "IOWriteOperationsPersec: 0\n" +
+            "Name: java\n" +
+            "PageFaultsPersec: 0\n" +
+            "PageFileBytes: 246562816\n" +
+            "PageFileBytesPeak: 251666432\n" +
+            "PercentPrivilegedTime: 0\n" +
+            "PercentProcessorTime: 2\n" +
+            "PercentUserTime: 0\n" +
+            "PoolNonpagedBytes: 23296\n" +
+            "PoolPagedBytes: 172744\n" +
+            "PriorityBase: 8\n" +
+            "PrivateBytes: 246562816\n" +
+            "ThreadCount: 24\n" +
+            "Timestamp_Object: \n" +
+            "Timestamp_PerfTime: \n" +
+            "Timestamp_Sys100NS: \n" +
+            "VirtualBytes: 2054496256\n" +
+            "VirtualBytesPeak: 2058690560\n" +
+            "WorkingSet: 85757952\n" +
+            "WorkingSetPeak: 97271808\n" +
+            "WorkingSetPrivate: 80453632\n";
+    private static final String WMI_PROCESS5_PERF = "Caption: \n" +
+            "CreatingProcessID: 3644\n" +
+            "Description: \n" +
+            "ElapsedTime: 5\n" +
+            "Frequency_Object: \n" +
+            "Frequency_PerfTime: \n" +
+            "Frequency_Sys100NS: \n" +
+            "HandleCount: 245\n" +
+            "IDProcess: 8160\n" +
+            "IODataBytesPersec: 0\n" +
+            "IODataOperationsPersec: 0\n" +
+            "IOOtherBytesPersec: 0\n" +
+            "IOOtherOperationsPersec: 0\n" +
+            "IOReadBytesPersec: 0\n" +
+            "IOReadOperationsPersec: 0\n" +
+            "IOWriteBytesPersec: 0\n" +
+            "IOWriteOperationsPersec: 0\n" +
+            "Name: java#1\n" +
+            "PageFaultsPersec: 0\n" +
+            "PageFileBytes: 250654720\n" +
+            "PageFileBytesPeak: 255041536\n" +
+            "PercentPrivilegedTime: 0\n" +
+            "PercentProcessorTime: 3\n" +
+            "PercentUserTime: 0\n" +
+            "PoolNonpagedBytes: 19704\n" +
+            "PoolPagedBytes: 179368\n" +
+            "PriorityBase: 8\n" +
+            "PrivateBytes: 250654720\n" +
+            "ThreadCount: 20\n" +
+            "Timestamp_Object: \n" +
+            "Timestamp_PerfTime: \n" +
+            "Timestamp_Sys100NS: \n" +
+            "VirtualBytes: 3683155968\n" +
+            "VirtualBytesPeak: 3683155968\n" +
+            "WorkingSet: 40710144\n" +
+            "WorkingSetPeak: 45494272\n" +
+            "WorkingSetPrivate: 30330880\n";
+
+}


### PR DESCRIPTION
-I try to use the 'master' branch just for delivered versions. To make the develops I always use a branch in snapshot called 'develop'. Could you make there the pull request?
**reopened for develop**
-I have to keep the project in 1.5 compilation because the two main projects I know that use JProcesses must work with this version of Java. That's why also JPowerShell and WMI4Java are in 1.5 :-(. Is it necessary for your modifications to be on java 1.6?
**fixed**
-I do not understand very well the method getWmi4java. For what I see the variable is always null so we return always a new instance. Moreover, wouldn't be better also to return an instance 'already VBS' (.get().VBSEngine()) as it is the implementation always used?
**I think default implementation is ok. 
The point of whole change is to create tests that are reprodusable, controllable and don't rely on developer to look through console output, which you can't if you use processes existing in your OS.
getWmi4Java method is created for 2 reasons:
1)replace wmi4Java object with controllable mock which returns hardcoded values for test pupposes
2)leave existing flow unchanged
That's why it still returns new object every time in prod code just as it was implemented previously** 