### PR TITLE
Support Norwegian locale dateformat from ps, as well as custom format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jprocesses</groupId>
     <artifactId>jProcesses</artifactId>
-    <version>1.6.2</version>
+    <version>1.6.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <name>jProcesses</name>
@@ -152,8 +152,8 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.5</maven.compiler.source>
-        <maven.compiler.target>1.5</maven.compiler.target>
-        <sonar.java.source>1.5</sonar.java.source>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <sonar.java.source>1.6</sonar.java.source>
     </properties>
 </project>

--- a/src/main/java/org/jutils/jprocesses/info/UnixProcessesService.java
+++ b/src/main/java/org/jutils/jprocesses/info/UnixProcessesService.java
@@ -15,6 +15,7 @@
  */
 package org.jutils.jprocesses.info;
 
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -62,14 +63,19 @@ class UnixProcessesService extends AbstractProcessesService {
                 element.put("virtual_memory", elements[index++]);
                 element.put("physical_memory", elements[index++]);
                 element.put("cpu_usage", elements[index++]);
+                index++; // Skip weekday
                 String longDate = elements[index++] + " " 
-                                + elements[index++] + " " 
                                 + elements[index++] + " " 
                                 + elements[index++]+ " " 
                                 + elements[index++];                
                 element.put("start_time", elements[index - 2]);
-                element.put("start_datetime", 
-                        ProcessesUtils.parseUnixLongTimeToFullDate(longDate));
+                try {
+                    element.put("start_datetime", 
+                            ProcessesUtils.parseUnixLongTimeToFullDate(longDate));
+                } catch (ParseException e) {
+                    element.put("start_datetime", "01/01/2000 00:00:00");
+                    System.err.println("Failed formatting date from ps: " + longDate + ", using \"01/01/2000 00:00:00\"");
+                }
                 element.put("proc_time", elements[index++]);
                 element.put("priority", elements[index++]);
                 element.put("proc_name", elements[index++]);                

--- a/src/main/java/org/jutils/jprocesses/util/ProcessesUtils.java
+++ b/src/main/java/org/jutils/jprocesses/util/ProcessesUtils.java
@@ -38,6 +38,7 @@ public class ProcessesUtils {
 
     private static final String CRLF = "\r\n";
     private static String customDateFormat;
+    private static Locale customLocale;
   
 
     //Hide constructor
@@ -162,14 +163,20 @@ public class ProcessesUtils {
      */
     public static String parseUnixLongTimeToFullDate(String longFormatDate) throws ParseException {
         DateFormat targetFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
-        List<String> formatsToTry = Arrays.asList("MMM dd HH:mm:ss yyyy", "dd MMM HH:mm:ss yyyy");
-        if (getCustomDateFormat() != null) {
-            List<String> newList = new ArrayList<String>();
-            newList.add(customDateFormat);
-            newList.addAll(formatsToTry);
-            formatsToTry = newList;
+        List<String> formatsToTry = new ArrayList<String>();
+        formatsToTry.addAll(Arrays.asList("MMM dd HH:mm:ss yyyy", "dd MMM HH:mm:ss yyyy"));
+        List<Locale> localesToTry = new ArrayList<Locale>();
+        localesToTry.addAll(Arrays.asList(Locale.getDefault(), 
+            Locale.getDefault(Locale.Category.FORMAT), 
+            Locale.ENGLISH)
+        );
+        if (getCustomDateFormat() != null) {           
+            formatsToTry.add(0, getCustomDateFormat());
         }
-        List<Locale> localesToTry = Arrays.asList(Locale.getDefault(), Locale.getDefault(Locale.Category.FORMAT), Locale.ENGLISH);
+        if (getCustomLocale() != null) {
+            localesToTry.add(0, getCustomLocale());
+        }
+      
         ParseException lastException = null;
         for (Locale locale : localesToTry) {
             for (String format : formatsToTry) {
@@ -197,5 +204,17 @@ public class ProcessesUtils {
      */
     public static void setCustomDateFormat(String dateFormat) {
         customDateFormat = dateFormat;
-    }   
+    }
+
+    public static Locale getCustomLocale() {
+      return customLocale;
+    }
+
+    /**
+     * Sets a custom locale if the defaults won't parse your ps output
+     * @param customLocale the Locale object to use
+     */
+    public static void setCustomLocale(Locale customLocale) {
+        ProcessesUtils.customLocale = customLocale;
+      }
 }

--- a/src/main/java/org/jutils/jprocesses/util/ProcessesUtils.java
+++ b/src/main/java/org/jutils/jprocesses/util/ProcessesUtils.java
@@ -21,6 +21,9 @@ import java.io.InputStreamReader;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,9 +33,12 @@ import java.util.logging.Logger;
  *
  * @author Javier Garcia Alonso
  */
+@SuppressWarnings("Since15")
 public class ProcessesUtils {
 
     private static final String CRLF = "\r\n";
+    private static String customDateFormat;
+  
 
     //Hide constructor
     private ProcessesUtils() {
@@ -154,16 +160,42 @@ public class ProcessesUtils {
      *
      * @return string with formatted date and time (mm/dd/yyyy HH:mm:ss)
      */
-    public static String parseUnixLongTimeToFullDate(String longFormatDate) {
-        DateFormat originalFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy", Locale.ENGLISH);
+    public static String parseUnixLongTimeToFullDate(String longFormatDate) throws ParseException {
         DateFormat targetFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
-        String returnedDate = null;
-        try {
-            returnedDate = targetFormat.format(originalFormat.parse(longFormatDate));
-        } catch (ParseException ex) {
-            Logger.getLogger(ProcessesUtils.class.getName()).log(Level.SEVERE, null, ex);
+        List<String> formatsToTry = Arrays.asList("MMM dd HH:mm:ss yyyy", "dd MMM HH:mm:ss yyyy");
+        if (getCustomDateFormat() != null) {
+            List<String> newList = new ArrayList<String>();
+            newList.add(customDateFormat);
+            newList.addAll(formatsToTry);
+            formatsToTry = newList;
         }
-
-        return returnedDate;
+        List<Locale> localesToTry = Arrays.asList(Locale.getDefault(), Locale.getDefault(Locale.Category.FORMAT), Locale.ENGLISH);
+        ParseException lastException = null;
+        for (Locale locale : localesToTry) {
+            for (String format : formatsToTry) {
+                DateFormat originalFormat = new SimpleDateFormat(format, locale);
+                try {
+                    return targetFormat.format(originalFormat.parse(longFormatDate));
+                } catch (ParseException ex) {
+                    lastException = ex;
+                }
+            }
+        }
+        throw lastException; 
     }
+    
+    public static String getCustomDateFormat() {
+        return customDateFormat;
+    }
+  
+    /**
+     * Custom date format to be used when parsing date string in "ps" output<br/>
+     * NOTE: We assume 5 space separated fields for date, where we pass the last 4 to the parser, e.g.
+     * for input text <code>søn 23 okt 08:30:00 2016</code> we would send <code>23 okt 08:30:00 2016</code>
+     * to the parser, so a pattern <code>dd MMM HH:mm:ss yyyy</code> would work.
+     * @param dateFormat the custom date format string to use
+     */
+    public static void setCustomDateFormat(String dateFormat) {
+        customDateFormat = dateFormat;
+    }   
 }

--- a/src/test/java/org/jutils/jprocesses/util/ProcessesUtilsTest.java
+++ b/src/test/java/org/jutils/jprocesses/util/ProcessesUtilsTest.java
@@ -3,9 +3,11 @@ package org.jutils.jprocesses.util;
 import org.junit.Test;
 
 import java.text.ParseException;
+import java.util.Locale;
 
 import static org.junit.Assert.*;
 
+@SuppressWarnings("Since15")
 public class ProcessesUtilsTest {
   @Test
   public void getCustomDateFormat() throws Exception {
@@ -15,6 +17,7 @@ public class ProcessesUtilsTest {
         fail();
       } catch (ParseException e) {}
       ProcessesUtils.setCustomDateFormat("dd MMM yyyy HH:mm:ss");
+      ProcessesUtils.setCustomLocale(Locale.forLanguageTag("no"));
       assertEquals("10/23/2016 08:30:00", ProcessesUtils.parseUnixLongTimeToFullDate("23 okt 2016 08:30:00"));  
   }
 

--- a/src/test/java/org/jutils/jprocesses/util/ProcessesUtilsTest.java
+++ b/src/test/java/org/jutils/jprocesses/util/ProcessesUtilsTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.*;
 public class ProcessesUtilsTest {
   @Test
   public void getCustomDateFormat() throws Exception {
-      assertEquals("10/23/2016 08:30:00", ProcessesUtils.parseUnixLongTimeToFullDate("23 okt 08:30:00 2016"));
+      assertEquals("10/23/2016 08:30:00", ProcessesUtils.parseUnixLongTimeToFullDate("oct 23 08:30:00 2016"));
       try {
         ProcessesUtils.parseUnixLongTimeToFullDate("23 okt 2016 08:30:00");
         fail();

--- a/src/test/java/org/jutils/jprocesses/util/ProcessesUtilsTest.java
+++ b/src/test/java/org/jutils/jprocesses/util/ProcessesUtilsTest.java
@@ -1,0 +1,21 @@
+package org.jutils.jprocesses.util;
+
+import org.junit.Test;
+
+import java.text.ParseException;
+
+import static org.junit.Assert.*;
+
+public class ProcessesUtilsTest {
+  @Test
+  public void getCustomDateFormat() throws Exception {
+      assertEquals("10/23/2016 08:30:00", ProcessesUtils.parseUnixLongTimeToFullDate("23 okt 08:30:00 2016"));
+      try {
+        ProcessesUtils.parseUnixLongTimeToFullDate("23 okt 2016 08:30:00");
+        fail();
+      } catch (ParseException e) {}
+      ProcessesUtils.setCustomDateFormat("dd MMM yyyy HH:mm:ss");
+      assertEquals("10/23/2016 08:30:00", ProcessesUtils.parseUnixLongTimeToFullDate("23 okt 2016 08:30:00"));  
+  }
+
+}


### PR DESCRIPTION
Got ParseException when running your tool on my Mac with Norwegian locale.
The parser for unix date from ps was hardcoded to English. 
This PR adds Norwegian-style format as an alternative (month day switch places)
and tries several combinations before throwing ParseException.
Also catch ParseException and fallback to `01/01/2000 00:00:00` if still cannot be parsed.
New method on ProcessUtils `setCustomDateFormat()` to support unknown formats.

Bump Java version from 1.5 to 1.6 since "noone" using 1.5 anymore and some of your original code requires 1.6 anyways.
